### PR TITLE
Feature contd update

### DIFF
--- a/src/cmd/cmdgazebo.rb.in
+++ b/src/cmd/cmdgazebo.rb.in
@@ -329,6 +329,11 @@ class Cmd
     filename = args.pop
     if filename and filename != 'gazebo'
       options['file'] = filename
+    else
+      # No world provided: default to empty.sdf, and restore the subcommand
+      # name to args so args[0] stays valid for later Process.spawn calls.
+      args.push(filename) if filename
+      options['file'] = 'empty.sdf'
     end
 
     options['command'] = args[0]

--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -1677,8 +1677,17 @@ QImage IgnRenderer::GetCpuFrame()
   }
 
   // PF_R8G8B8 produces 3 bytes/pixel (R,G,B). Use Format_RGB888.
-  // Deep-copy the buffer so the QImage outlives cameraImage.
+  // IMPORTANT: Ogre Copy() writes packed rows (bytesPerLine = w * 3). Qt's
+  // default bytesPerLine for Format_RGB888 rounds up to 4-byte alignment,
+  // which shifts every row by 1 byte when width*3 is not a multiple of 4.
+  // That accumulated shift is what caused the startup "stripes + double
+  // camera view" until a window resize happened to land on a multiple-of-4
+  // width. Pass the packed stride explicitly so Qt reads the buffer exactly
+  // as Ogre wrote it.
+  //
+  // Deep-copy so the QImage outlives cameraImage.
   return QImage(data, static_cast<int>(w), static_cast<int>(h),
+      static_cast<qsizetype>(w) * 3,
       QImage::Format_RGB888).copy();
 }
 
@@ -2208,15 +2217,15 @@ void RenderThread::SizeChanged()
 TextureNode::TextureNode(QQuickWindow *_window)
     : window(_window)
 {
-  // Our texture node must have a texture, so use the default 0 texture.
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-  this->texture = this->window->createTextureFromId(0, QSize(1, 1));
-#else
-  void * nativeLayout;
-  this->texture = this->window->createTextureFromNativeObject(
-      QQuickWindow::NativeObjectTexture, &nativeLayout, 0, QSize(1, 1),
-      QQuickWindow::TextureIsOpaque);
-#endif
+  // Our texture node must have a valid texture before the first real frame
+  // arrives. Creating it from a 1x1 black QImage matches the CPU-readback path
+  // used for the actual frames (PrepareNode uses createTextureFromImage), and
+  // avoids the uninitialized-native-object UB that produced garbage stripes
+  // and a double-camera-view on startup until the window was resized.
+  QImage placeholder(1, 1, QImage::Format_RGB888);
+  placeholder.fill(Qt::black);
+  this->texture = this->window->createTextureFromImage(
+      placeholder, QQuickWindow::TextureIsOpaque);
   this->setTexture(this->texture);
 }
 


### PR DESCRIPTION
## Feature contd update

fix(macOS): resolve Scene3D startup artifacts and improve empty world launch behavior

## PR Description

This PR contains two focused fixes for the macOS Gazebo/Citadel GUI experience:

1. **Fixes startup rendering artifacts** in Scene3D (striping / corrupted initial frame / invalid texture state).
2. **Improves default launch behavior** by opening `empty.sdf` when no world is provided, while preserving subcommand arguments during process execution.

Together, these changes make first launch and normal startup behavior significantly smoother for macOS users.

---

## What's Included

### 1. Scene3D Startup Artifact Fix (macOS)

Resolved visual corruption occurring on startup in the 3D viewport.

#### Fixes applied:

* Corrected **CPU frame stride handling** for `RGB888` images.
* Prevented row misalignment when copying rendered frames into Qt image buffers.
* Initialized Scene3D texture with a **valid placeholder texture** before first real frame arrives.
* Eliminated startup artifacts such as:

  * stripes
  * distorted rows
  * duplicated / split camera view
  * undefined first-frame texture garbage

#### Impact:

The Scene3D viewport now starts cleanly and renders correctly without requiring window resize workarounds.

---

### 2. Better Launch Defaults on macOS

Improved application startup when no world file is explicitly passed.

#### Changes:

* Default to launching **`empty.sdf`** when no world argument is supplied.
* Preserve subcommand arguments correctly through `Process.spawn`.

#### Impact:

Users can launch more reliably from shell/scripts without broken argument forwarding or needing to manually specify a world file every time.

---

## Why This Matters

This PR removes two major rough edges in the macOS experience:

* Broken first impression from corrupted startup rendering.
* Confusing startup behavior when launching without explicit world files.

It improves both **visual stability** and **CLI usability**.

---

## Commits Included

| SHA       | Message                                                                                                                                |
| --------- | -------------------------------------------------------------------------------------------------------------------------------------- |
| `cf6d99c` | correct CPU frame stride for RGB888 images and initialize Scene3D texture with valid placeholder to prevent startup artifacts on macOS |
| `1ea7884` | default to empty.sdf when no world file is provided and preserve subcommand args for Process.spawn execution on macOS                  |

---

## Suggested Review Focus

* `Scene3D.cc` / CPU frame upload path
* Qt `QImage` stride handling
* Texture initialization lifecycle
* macOS launch wrapper / process spawning path
* Default world file selection logic

---

## Result

macOS users should now see:

* Clean Scene3D startup
* No resize workaround needed
* Reliable launch from terminal
* Sensible default empty world behavior
