### PR TITLE
preserve SDF-defined Scene3D background color by removing hardcoded v…

### DIFF
--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -1712,9 +1712,12 @@ std::string IgnRenderer::Initialize()
   if (!scene)
     return "Failed to create a 3D scene.";
 
-  // Set background color before creating the camera so CreateRenderTexture()
-  // reads it correctly. The default is black; use a visible gray for testing.
-  scene->SetBackgroundColor(math::Color(0.3f, 0.3f, 0.3f, 1.0f));
+  // Background color was applied by RenderUtil::Init() (above) from the SDF's
+  // <background_color> element via RenderUtil::SetBackgroundColor() — see
+  // RenderUtil.cc:1232-1236. Do not override it here; that hides per-world
+  // overrides from the SDF and forces every viewport to the same hardcoded
+  // value. (Earlier dev versions hardcoded 0.3,0.3,0.3 here as a debug aid;
+  // that hardcode masked the SDF chain entirely.)
 
   auto root = scene->RootVisual();
 


### PR DESCRIPTION
## Preserve SDF-defined Scene3D background colors

This PR removes a hardcoded background color override in the Scene3D GUI initialization path so viewport backgrounds correctly respect values defined in world SDF files.

---

## 🧩 Summary

Previously, Scene3D forced every viewport to use a fixed gray background during initialization:

```cpp id="p3w261"
scene->SetBackgroundColor(math::Color(0.3f, 0.3f, 0.3f, 1.0f));
```

That override ignored any `<background_color>` specified in the loaded world file.

This PR removes that behavior and allows the background color already applied through the normal render initialization pipeline to remain in effect.

---

## 🔧 What Changed

### Before

During Scene3D startup, the GUI always replaced the world background with a hardcoded black value.

Result:

* all worlds looked the same
* custom sky/background colors were lost. It was always black background.
* SDF settings appeared broken
* debugging defaults leaked into normal runtime behavior

### After

Scene3D now preserves the background color configured earlier by the rendering system via:

* RenderUtil initialization
* SDF `<background_color>` world settings
